### PR TITLE
Handling case of syncing users (not 'new')

### DIFF
--- a/server/methods.js
+++ b/server/methods.js
@@ -57,7 +57,8 @@ Meteor.methods({
       ];
       profile_data = _.omit(data.content, cleanUpProfile);
 
-      if (data.content.is_new) {
+      // If a user doesn't exist, create one.
+      if(!(Meteor.users.findOne({"profile.uid" : data.content.uid}))) {      
         // Create User
         Accounts.createUser({
           username: data.content.name,


### PR DESCRIPTION
Detected a bug where if users were synced to Meteor while missing the `is_new` flag on new entities, the user wasn't created in Meteor. This fixes that by checking if a user exists in the db first.