### PR TITLE
Returning data from Meteor as acknowledgement of receipt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Below is a sample `settings.json` file to be included in the root of your Meteor
       },
       "drupal_ddp": {
         "debug_data": true,
-        "ddp_url": "http://drupalddp.dev",
+        "drupal_url": "http://your_drupal_url",
         "restws_user": "restws_xxxxx",
         "restws_pass": "your_password",
         "restws_read_user": "restws_readonly_xxxxx",

--- a/client/methods.js
+++ b/client/methods.js
@@ -1,7 +1,7 @@
 if (Meteor.isClient) {
   Meteor.startup(function () {
     if (Meteor.settings.public.drupal_ddp_access_private_files === true) {
-      Meteor.call('getDrupalDdpToken', 'read', function(err, response) {
+      Meteor.call('getDrupalSessionToken', 'read', function(err, response) {
         if (!err) {
           // Getting the upper level domain of the current site.
           var urlParts = location.hostname.split('.');

--- a/history.md
+++ b/history.md
@@ -1,0 +1,10 @@
+v.0.1.2
+----
+- Changed settings.json variable name from `ddp_url` to `drupal_ddp` for added
+clarity of its function.
+- Added more debugging output when `debug` is set to `true`.
+- `DrupalSaveNode` method now returns `nid/uid/tid` and `timestamp` to help with
+queueing of posts from Drupal -> Meteor.
+- Added dependency on `matteodem:server-session` package. Sesson tokens are now
+stored in server session to reduce the amount of concurrent active sessions
+for the `restws_` user in Drupal when data is updated from Meteor -> Drupal.

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'hb5:drupal-ddp',
   summary: 'Drupal and Meteor integration over DDP',
   git: 'https://github.com/hb5co/drupal-ddp',
-  version: '0.1.1'
+  version: '0.1.2'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -11,30 +11,33 @@ Package.onUse(function(api) {
 
   var both = ['client', 'server'];
 
-  // Packages for Client & Server
+  // Packages for Client & Server.
   api.use([
     'mongo',
     'accounts-password',
     'http'
     ], both);
 
-  // Files for Client
+  // Packages for Server.
+  api.use('matteodem:server-session', 'server');
+
+  // Files for Client.
   api.addFiles([
     'client/methods.js',
     ], both);
 
-  // Files for Client & Server
+  // Files for Client & Server.
   api.addFiles([
     'collections/taxonomies.js',
     ], both);
 
-  // Files for Server
+  // Files for Server.
   api.addFiles([
     'server/methods.js',
     'server/config.js'
     ], 'server');
 
-  // Publish Collections to Client
+  // Publish Collections to Client.
   api.export('drupalDdpTaxonomies');
   api.export('DrupalDdp');
 });

--- a/server/methods.js
+++ b/server/methods.js
@@ -144,7 +144,6 @@ Meteor.methods({
       Meteor.users.update({_id : userId}, {$set: {'emails.0.verified' : true}});
 
       // Return object as an acknowledgement of Meteor getting data.
-      var currentTime = Math.floor(new Date().getTime() / 1000);
       var returnMessage = {
         'uid': data.content.uid,
         'timestamp': currentTime
@@ -152,7 +151,7 @@ Meteor.methods({
       return returnMessage;
     }
   },
-  getDrupalDdpToken: function(type) {
+  getDrupalSessionToken: function(type) {
     if (type === 'read') {
       var options = {
         url: Meteor.settings.drupal_ddp.drupal_url + "/restws/session/token",

--- a/server/methods.js
+++ b/server/methods.js
@@ -11,9 +11,8 @@ Meteor.methods({
       }
     }
 
-    if (Meteor.settings.drupal_ddp.debug_data === true) {
-      console.log(data);
-    }
+    if (Meteor.settings.drupal_ddp.debug_data === true) { console.log(data); }
+
     // Handle Nodes.
     if (data.content.ddp_type == 'node') {
       var actualColl = DrupalDdp.collections[data.content.type];

--- a/server/methods.js
+++ b/server/methods.js
@@ -30,6 +30,15 @@ Meteor.methods({
         // Update existing posts.
         actualColl.upsert({nid: data.content.nid},{$set: data.content});
       }
+
+      // Return object as an acknowledgement of Meteor getting data.
+      var currentTime = Math.floor(new Date().getTime() / 1000);
+      var returnMessage = {
+        'nid': data.content.nid,
+        'type': data.content.type,
+        'timestamp': currentTime
+      };
+      return returnMessage;
     }
 
     // Handle Taxonomies.
@@ -46,6 +55,15 @@ Meteor.methods({
           $set: data.content
         });
       }
+
+      // Return object as an acknowledgement of Meteor getting data.
+      var currentTime = Math.floor(new Date().getTime() / 1000);
+      var returnMessage = {
+        'tid': data.content.tid,
+        'vocab': data.content.vocabulary_machine_name,
+        'timestamp': currentTime
+      };
+      return returnMessage;
     }
 
     // Handle Users.
@@ -88,6 +106,14 @@ Meteor.methods({
           }
         );
       }
+
+      // Return object as an acknowledgement of Meteor getting data.
+      var currentTime = Math.floor(new Date().getTime() / 1000);
+      var returnMessage = {
+        'uid': data.content.uid,
+        'timestamp': currentTime
+      };
+      return returnMessage;
     }
 
     if (data.content.ddp_type === 'update_user_password') {
@@ -118,6 +144,14 @@ Meteor.methods({
       // Set user password and 'verify' their account.
       Meteor.users.update({_id : userId}, {$set: {'services.password.bcrypt' : passwordHash}});
       Meteor.users.update({_id : userId}, {$set: {'emails.0.verified' : true}});
+
+      // Return object as an acknowledgement of Meteor getting data.
+      var currentTime = Math.floor(new Date().getTime() / 1000);
+      var returnMessage = {
+        'uid': data.content.uid,
+        'timestamp': currentTime
+      };
+      return returnMessage;
     }
   },
   getDrupalDdpToken: function(type) {

--- a/server/methods.js
+++ b/server/methods.js
@@ -4,6 +4,7 @@ Meteor.methods({
   },
   // Accept node inserts and updates from Drupal.
   DrupalSaveNode: function (data) {
+    var currentTime = Math.floor(new Date().getTime() / 1000);
     // Implementation of simple security.
     if (Meteor.settings.drupal_ddp.simple_security === true) {
       if (Meteor.settings.drupal_ddp.simple_security_token !== data.simple_security) {
@@ -32,7 +33,6 @@ Meteor.methods({
       }
 
       // Return object as an acknowledgement of Meteor getting data.
-      var currentTime = Math.floor(new Date().getTime() / 1000);
       var returnMessage = {
         'nid': data.content.nid,
         'type': data.content.type,
@@ -57,7 +57,6 @@ Meteor.methods({
       }
 
       // Return object as an acknowledgement of Meteor getting data.
-      var currentTime = Math.floor(new Date().getTime() / 1000);
       var returnMessage = {
         'tid': data.content.tid,
         'vocab': data.content.vocabulary_machine_name,
@@ -108,7 +107,6 @@ Meteor.methods({
       }
 
       // Return object as an acknowledgement of Meteor getting data.
-      var currentTime = Math.floor(new Date().getTime() / 1000);
       var returnMessage = {
         'uid': data.content.uid,
         'timestamp': currentTime

--- a/server/methods.js
+++ b/server/methods.js
@@ -263,7 +263,7 @@ Meteor.methods({
         Meteor.call('updateNodeInDrupal', node, numTries);
       } else {
         if (Meteor.settings.drupal_ddp.debug_data === true) {
-          console.log('== Server Response ==');
+          console.log('== Server Error Response ==');
           console.log(e);
         }
         return e;


### PR DESCRIPTION
- Added `matteodem:server-session` package to handing Drupal session token caching.
- Returning data from `DrupalSaveNode` to serve as acknowledgement of content receipt.
- Added more debugging data when `debug` is set to `true`