### PR TITLE
bypass forced validation of `audit-argument-checks`

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
-  name: 'klokie:drupal-ddp',
+  name: 'hb5:drupal-ddp',
   summary: 'Drupal and Meteor integration over DDP',
-  git: 'https://github.com/klokie/drupal-ddp',
+  git: 'https://github.com/hb5co/drupal-ddp',
   version: '0.1.4'
 });
 
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     'mongo',
     'accounts-password',
     'http'
-  ], both);
+    ], both);
 
   // Packages for Server.
   api.use('matteodem:server-session@0.4.2', 'server');
@@ -24,18 +24,18 @@ Package.onUse(function(api) {
   // Files for Client.
   api.addFiles([
     'client/methods.js',
-  ], both);
+    ], both);
 
   // Files for Client & Server.
   api.addFiles([
     'collections/taxonomies.js',
-  ], both);
+    ], both);
 
   // Files for Server.
   api.addFiles([
     'server/methods.js',
     'server/config.js'
-  ], 'server');
+    ], 'server');
 
   // Publish Collections to Client.
   api.export('drupalDdpTaxonomies');

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
-  name: 'hb5:drupal-ddp',
+  name: 'klokie:drupal-ddp',
   summary: 'Drupal and Meteor integration over DDP',
-  git: 'https://github.com/hb5co/drupal-ddp',
+  git: 'https://github.com/klokie/drupal-ddp',
   version: '0.1.4'
 });
 
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     'mongo',
     'accounts-password',
     'http'
-    ], both);
+  ], both);
 
   // Packages for Server.
   api.use('matteodem:server-session@0.4.2', 'server');
@@ -24,18 +24,18 @@ Package.onUse(function(api) {
   // Files for Client.
   api.addFiles([
     'client/methods.js',
-    ], both);
+  ], both);
 
   // Files for Client & Server.
   api.addFiles([
     'collections/taxonomies.js',
-    ], both);
+  ], both);
 
   // Files for Server.
   api.addFiles([
     'server/methods.js',
     'server/config.js'
-    ], 'server');
+  ], 'server');
 
   // Publish Collections to Client.
   api.export('drupalDdpTaxonomies');

--- a/server/methods.js
+++ b/server/methods.js
@@ -29,6 +29,8 @@ Meteor.methods({
       // Otherwise, insert/update.
       else {
         // Update existing posts.
+        // bypass forced validation of `audit-argument-checks`
+        check(data.content, [Match.Any]);
         actualColl.upsert({nid: data.content.nid},{$set: data.content});
       }
 
@@ -52,6 +54,8 @@ Meteor.methods({
         actualTax.remove({tid: data.content.tid});
       }
       else {
+        // bypass forced validation of `audit-argument-checks`
+        check(data.content, [Match.Any]);
         actualTax.upsert({
           tid: data.content.tid
         },{


### PR DESCRIPTION
Hi, this is a great package!
I ran into some problems when using it with Meteor 1.3 and [audit-argument-checks](https://docs.meteor.com/packages/audit-argument-checks.html), which prevents unvalidated inserts/upserts. 

```
Exception while invoking method 'DrupalSaveNode' Error: Did not check() all arguments during call to 'DrupalSaveNode'
at [object Object]._.extend.throwUnlessAllArgumentsHaveBeenChecked (packages/check/match.js:432:1)
at Object.exports.Match._failIfArgumentsAreNotAllChecked (packages/check/match.js:110:1)
at maybeAuditArgumentChecks (packages/ddp-server/livedata_server.js:1701:18)
at packages/ddp-server/livedata_server.js:711:19
at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
at packages/ddp-server/livedata_server.js:709:40
at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
at packages/ddp-server/livedata_server.js:707:46
at tryCallTwo (/Users/klokie/.meteor/packages/promise/.0.6.7.1d67q83++os+web.browser+web.cordova/npm/node_modules/meteor-promise/node_modules/promise/lib/core.js:45:5)
at doResolve (/Users/klokie/.meteor/packages/promise/.0.6.7.1d67q83++os+web.browser+web.cordova/npm/node_modules/meteor-promise/node_modules/promise/lib/core.js:200:13)
```

Please have a look at the PR, which seems to bypass these issues. Thanks!
